### PR TITLE
Feature: Add support for Spanish

### DIFF
--- a/ichikoto/settings.py
+++ b/ichikoto/settings.py
@@ -158,6 +158,15 @@ if scheduler_minutes is not None and scheduler_minutes.isdigit() and 0 <= int(sc
 else:
     EMAIL_SCHEDULER_MINUTES = 0
 
+# Grabs the users target language
+language = os.getenv("TARGET_LANGUAGE")
+available_languages = ["Japanese", "Spanish"]
+
+if language.capitalize().strip() in available_languages:
+    TARGET_LANGUAGE = language.capitalize().strip()
+else:
+    TARGET_LANGUAGE = available_languages[0]
+
 
 # Logging backend settings
 LOGGING = {

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,8 @@ def main():
             file.write('# 12-23 ==> pm\n')
             file.write('EMAIL_SCHEDULER_HOUR=12\n')
             file.write('EMAIL_SCHEDULER_MINUTES=0\n')
+            file.write('\n')
+            file.write('TARGET_LANGUAGE="Japenese"\n')
 
     # install required packages
     print("Installing required packages...")

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ def main():
             file.write('EMAIL_SCHEDULER_HOUR=12\n')
             file.write('EMAIL_SCHEDULER_MINUTES=0\n')
             file.write('\n')
-            file.write('TARGET_LANGUAGE="Japenese"\n')
+            file.write('TARGET_LANGUAGE="Japanese"\n')
 
     # install required packages
     print("Installing required packages...")

--- a/word_manager/services/gpt_service.py
+++ b/word_manager/services/gpt_service.py
@@ -25,17 +25,17 @@ def send_prompt(manual_mode=False, simulate_error=None):
             return {"choices": [{"message": {"content": "Sample response for testing."}}]}
 
         content_message = f"Request:\n"
-        content_message += f"Word in Japanese: Give me a useful word to know"
-        word_objects = Word.objects.filter(language="Japanese")
+        content_message += f"Word in {settings.TARGET_LANGUAGE}: Give me a useful word to know"
+        word_objects = Word.objects.filter(language=settings.TARGET_LANGUAGE)
         word_list = [word.word for word in word_objects]
         if word_list:
             word_string = ', '.join(word_list)
             content_message += f" that is not in this list: [{word_string}]"
-        content_message += f".\nDefinition in Japanese: Give the definition of the word in Japanese with furigana.\n"
-        content_message += f"Context Sentence in Japanese: Offer a sentence using the word in Japanese with furigana.\n"
-        content_message += f"\nResponse Structure:\nWord: [In Japanese]\n"
-        content_message += f"Definition: [In Japanese with furigana]\n"
-        content_message += f"Context Sentence: [In Japanese with furigana]\n"
+        content_message += f".\nDefinition in {settings.TARGET_LANGUAGE}: Give the definition of the word in {settings.TARGET_LANGUAGE} with furigana (if applicable).\n"
+        content_message += f"Context Sentence in {settings.TARGET_LANGUAGE}: Offer a sentence using the word in {settings.TARGET_LANGUAGE} with furigana (if applicable).\n"
+        content_message += f"\nResponse Structure:\nWord: [In {settings.TARGET_LANGUAGE}]\n"
+        content_message += f"Definition: [In {settings.TARGET_LANGUAGE} with furigana (if applicable)]\n"
+        content_message += f"Context Sentence: [In {settings.TARGET_LANGUAGE} with furigana (if applicable)]\n"
         content_message += f"Translation:\nWord in English:\n"
         content_message += f"Definition in English:\n"
         content_message += f"Context Sentence in English:"

--- a/word_manager/services/word_service.py
+++ b/word_manager/services/word_service.py
@@ -1,4 +1,5 @@
 from ..models import Word
+from django.conf import settings
 import logging
 import re
 
@@ -18,11 +19,11 @@ def extract_word(response_text):
         return None
 
 
-def store_word(response_text, language="Japanese"):
+def store_word(response_text):
     try:
         word = extract_word(response_text)
         if word:
-            new_word = Word(word=word, language=language)
+            new_word = Word(word=word, language=settings.TARGET_LANGUAGE)
             new_word.save()
             logger.info(f"The word '{word}' has been successfully stored.")
         else:

--- a/word_manager/tests/test_word_service.py
+++ b/word_manager/tests/test_word_service.py
@@ -1,6 +1,8 @@
 from django.test import TestCase
+from django.conf import settings
 from ..services.word_service import extract_word, store_word
 from ..models import Word
+import os
 
 
 class ExtractWordTests(TestCase):
@@ -26,18 +28,24 @@ class ExtractWordTests(TestCase):
 
 class StoreWordTests(TestCase):
 
+    def setUp(self):
+        settings.TARGET_LANGUAGE = "Spanish"
+
+    def tearDown(self):
+        del settings.TARGET_LANGUAGE
+
     # word is stored successfully
     def test_store_word_success(self):
         response_text = "Word: Cat (Ka-tuh)"
-        store_word(response_text, language="Japanese")
+        store_word(response_text)
         saved_word = Word.objects.last()
         self.assertIsNotNone(saved_word)
         self.assertEqual(saved_word.word, "Cat")
-        self.assertEqual(saved_word.language, "Japanese")
+        self.assertEqual(saved_word.language, "Spanish")
 
     # no word exists
     def test_store_word_no_word(self):
         response_text = "No word here"
-        store_word(response_text, language="Japanese")
+        store_word(response_text)
         saved_word = Word.objects.last()
         self.assertIsNone(saved_word)


### PR DESCRIPTION
Relevant issue: #4

# Description

### Brief Overview
This PR adds a `TARGET_LANGUAGE` key to the `.env` file. By default the value of `TARGET_LANGUAGE` is Japanese, but Spanish is also a valid option. It also replaces all instances of `'Japanese'` with `settings.TARGET_LANGUAGE`. As a result, the tests file for the `word_service` function had to be modified to ensure the correct language is being stored. Furthermore, the pormpt for the OpenAI was slightly modified to only return furigana _if_ it applies to that language

### Tests
The `test_word_service` file was modified so that the `StoreWordTests` class uses the environment variable to confirm that the correct language was stored in the database. All tests are go ✅

### Example
Below is a screenshot of the email I received from ichikoto, with `TARGET_LANGUAGE="Spanish"`:
<img width="495" alt="Screenshot 2023-11-20 at 6 44 18 PM" src="https://github.com/MattTuccillo/ichikoto/assets/55603689/d0c5942c-0aea-45ec-83c6-3c68b122b174">


### Disclaimers
I was a little late in seeing that no changes should be made to `setup.py`. My approach to adding support for Spanish while still keeping Japanese the default was by modifying `setup.py` and adding `TARGET_LANGUAGE="Japanese"` to the `.env` file. I think this approach would make it easier to add support for even more languages, while keeping the source code relatively clean of too many conditionals for the language used. 

It also reduces the complexity of the `store_word` function by removing the need for a second argument. Nonetheless, if the PR is disapproved for this reason I will be happy to visit other avenues where `setup.py` is not modified
